### PR TITLE
feat(web): Implement Keyboard Shortcuts for Power Users

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -9,6 +9,7 @@ import { AuthProvider } from '@/components/providers/auth-provider';
 import { WebVitalsProvider } from '@/components/providers/web-vitals-provider';
 import { BrowserLogCollectorProvider } from '@/components/providers/browser-log-collector-provider';
 import { AnalyticsProvider } from '@/components/providers/analytics-provider';
+import { KeyboardShortcutsProvider } from '@/components/providers/keyboard-shortcuts-provider';
 import { Toaster } from 'sonner';
 import './globals.css';
 
@@ -59,12 +60,14 @@ export default function RootLayout({
             <RollbarProvider>
               <WebVitalsProvider>
                 <BrowserLogCollectorProvider>
-                <AnalyticsProvider>
-                  <ErrorBoundary>
-                    {children}
-                    <Toaster richColors position="top-right" />
-                  </ErrorBoundary>
-                </AnalyticsProvider>
+                  <AnalyticsProvider>
+                    <KeyboardShortcutsProvider>
+                      <ErrorBoundary>
+                        {children}
+                        <Toaster richColors position="top-right" />
+                      </ErrorBoundary>
+                    </KeyboardShortcutsProvider>
+                  </AnalyticsProvider>
                 </BrowserLogCollectorProvider>
               </WebVitalsProvider>
             </RollbarProvider>

--- a/web/components/providers/keyboard-shortcuts-provider.tsx
+++ b/web/components/providers/keyboard-shortcuts-provider.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { createContext, useContext, useCallback, useState } from 'react';
+import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
+import { ShortcutsHelpModal } from '@/components/shortcuts-help-modal';
+
+interface KeyboardShortcutsContextValue {
+    shortcutsHelpOpen: boolean;
+    setShortcutsHelpOpen: (open: boolean) => void;
+    openShortcutsHelp: () => void;
+}
+
+const KeyboardShortcutsContext = createContext<KeyboardShortcutsContextValue | null>(null);
+
+export function useKeyboardShortcutsContext() {
+    const context = useContext(KeyboardShortcutsContext);
+    if (!context) {
+        throw new Error('useKeyboardShortcutsContext must be used within KeyboardShortcutsProvider');
+    }
+    return context;
+}
+
+interface KeyboardShortcutsProviderProps {
+    children: React.ReactNode;
+}
+
+export function KeyboardShortcutsProvider({ children }: KeyboardShortcutsProviderProps) {
+    const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false);
+
+    const openShortcutsHelp = useCallback(() => {
+        setShortcutsHelpOpen(true);
+    }, []);
+
+    const handleShowShortcutsHelp = useCallback(() => {
+        setShortcutsHelpOpen(prev => !prev);
+    }, []);
+
+    const handleCloseModal = useCallback(() => {
+        if (shortcutsHelpOpen) {
+            setShortcutsHelpOpen(false);
+            return true;
+        }
+        return false;
+    }, [shortcutsHelpOpen]);
+
+    useKeyboardShortcuts({
+        onShowShortcutsHelp: handleShowShortcutsHelp,
+        onCloseModal: handleCloseModal,
+        enabled: true,
+    });
+
+    return (
+        <KeyboardShortcutsContext.Provider
+            value={{
+                shortcutsHelpOpen,
+                setShortcutsHelpOpen,
+                openShortcutsHelp,
+            }}
+        >
+            {children}
+            <ShortcutsHelpModal
+                open={shortcutsHelpOpen}
+                onOpenChange={setShortcutsHelpOpen}
+            />
+        </KeyboardShortcutsContext.Provider>
+    );
+}

--- a/web/components/shortcuts-help-modal.tsx
+++ b/web/components/shortcuts-help-modal.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+    getShortcutGroups,
+    searchShortcuts,
+    formatShortcutKeys,
+    type Shortcut,
+    type ShortcutGroup,
+} from '@/lib/shortcuts-config';
+import { Search, Keyboard, Printer, X } from 'lucide-react';
+
+interface ShortcutsHelpModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+function ShortcutKey({ children }: { children: React.ReactNode }) {
+    return (
+        <kbd className="inline-flex items-center justify-center min-w-[24px] h-6 px-2 text-xs font-bold bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md text-slate-700 dark:text-slate-300 shadow-sm">
+            {children}
+        </kbd>
+    );
+}
+
+function ShortcutRow({ shortcut }: { shortcut: Shortcut }) {
+    const formattedKeys = formatShortcutKeys(shortcut.keys, shortcut.isSequence);
+    const keyParts = shortcut.isSequence
+        ? shortcut.keys
+        : formattedKeys.split('+');
+
+    return (
+        <div className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors">
+            <span className="text-sm text-slate-700 dark:text-slate-300">
+                {shortcut.description}
+            </span>
+            <div className="flex items-center gap-1">
+                {shortcut.isSequence ? (
+                    <>
+                        <ShortcutKey>{shortcut.keys[0].toUpperCase()}</ShortcutKey>
+                        <span className="text-xs text-slate-400 mx-1">then</span>
+                        <ShortcutKey>{shortcut.keys[1] === '?' ? '?' : shortcut.keys[1].toUpperCase()}</ShortcutKey>
+                    </>
+                ) : (
+                    keyParts.map((key, index) => (
+                        <React.Fragment key={index}>
+                            {index > 0 && <span className="text-xs text-slate-400">+</span>}
+                            <ShortcutKey>{key}</ShortcutKey>
+                        </React.Fragment>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}
+
+function ShortcutSection({ group }: { group: ShortcutGroup }) {
+    return (
+        <div className="mb-6">
+            <h3 className="text-xs font-black uppercase tracking-widest text-slate-500 dark:text-slate-400 mb-3 px-3">
+                {group.label}
+            </h3>
+            <div className="space-y-1">
+                {group.shortcuts.map(shortcut => (
+                    <ShortcutRow key={shortcut.id} shortcut={shortcut} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export function ShortcutsHelpModal({ open, onOpenChange }: ShortcutsHelpModalProps) {
+    const [searchQuery, setSearchQuery] = useState('');
+    const shortcutGroups = useMemo(() => getShortcutGroups(), []);
+
+    const filteredGroups = useMemo(() => {
+        if (!searchQuery.trim()) {
+            return shortcutGroups;
+        }
+
+        const matchingShortcuts = searchShortcuts(searchQuery);
+        const matchingIds = new Set(matchingShortcuts.map(s => s.id));
+
+        return shortcutGroups
+            .map(group => ({
+                ...group,
+                shortcuts: group.shortcuts.filter(s => matchingIds.has(s.id)),
+            }))
+            .filter(group => group.shortcuts.length > 0);
+    }, [searchQuery, shortcutGroups]);
+
+    const handlePrint = () => {
+        const printWindow = window.open('', '_blank');
+        if (printWindow) {
+            printWindow.document.write(`
+                <html>
+                    <head>
+                        <title>Keyboard Shortcuts - SafeSpace</title>
+                        <style>
+                            body { font-family: system-ui, sans-serif; padding: 40px; max-width: 800px; margin: 0 auto; }
+                            h1 { font-size: 24px; margin-bottom: 32px; }
+                            h2 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.1em; color: #666; margin-top: 24px; margin-bottom: 12px; }
+                            .shortcut { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #eee; }
+                            .description { color: #333; }
+                            .keys { font-family: monospace; background: #f5f5f5; padding: 2px 8px; border-radius: 4px; }
+                        </style>
+                    </head>
+                    <body>
+                        <h1>Keyboard Shortcuts</h1>
+                        ${shortcutGroups.map(group => `
+                            <h2>${group.label}</h2>
+                            ${group.shortcuts.map(s => `
+                                <div class="shortcut">
+                                    <span class="description">${s.description}</span>
+                                    <span class="keys">${formatShortcutKeys(s.keys, s.isSequence)}</span>
+                                </div>
+                            `).join('')}
+                        `).join('')}
+                    </body>
+                </html>
+            `);
+            printWindow.document.close();
+            printWindow.print();
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
+                <DialogHeader className="flex-shrink-0">
+                    <DialogTitle className="flex items-center gap-2">
+                        <Keyboard className="w-5 h-5 text-primary" />
+                        Keyboard Shortcuts
+                    </DialogTitle>
+                </DialogHeader>
+
+                <div className="flex items-center gap-2 mb-4 flex-shrink-0">
+                    <div className="flex-1 relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                        <input
+                            type="text"
+                            placeholder="Search shortcuts..."
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            className={cn(
+                                "w-full pl-10 pr-4 py-2 text-sm rounded-xl border-2 border-slate-100 dark:border-slate-800",
+                                "bg-slate-50 dark:bg-slate-900 focus:border-primary focus:outline-none",
+                                "placeholder:text-slate-400"
+                            )}
+                        />
+                        {searchQuery && (
+                            <button
+                                onClick={() => setSearchQuery('')}
+                                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handlePrint}
+                        className="flex items-center gap-2"
+                    >
+                        <Printer className="w-4 h-4" />
+                        Print
+                    </Button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto pr-2 -mr-2">
+                    {filteredGroups.length > 0 ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8">
+                            <div>
+                                {filteredGroups
+                                    .filter((_, i) => i % 2 === 0)
+                                    .map(group => (
+                                        <ShortcutSection key={group.category} group={group} />
+                                    ))}
+                            </div>
+                            <div>
+                                {filteredGroups
+                                    .filter((_, i) => i % 2 === 1)
+                                    .map(group => (
+                                        <ShortcutSection key={group.category} group={group} />
+                                    ))}
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="text-center py-12 text-slate-500">
+                            <Keyboard className="w-12 h-12 mx-auto mb-4 opacity-30" />
+                            <p>No shortcuts found for &ldquo;{searchQuery}&rdquo;</p>
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex-shrink-0 pt-4 mt-4 border-t border-slate-100 dark:border-slate-800">
+                    <p className="text-xs text-slate-500 text-center">
+                        Press <ShortcutKey>Esc</ShortcutKey> to close or <ShortcutKey>Cmd</ShortcutKey>+<ShortcutKey>/</ShortcutKey> to toggle
+                    </p>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/web/hooks/use-keyboard-shortcuts.ts
+++ b/web/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,308 @@
+'use client';
+
+import { useEffect, useCallback, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { isMac, shortcuts, type Shortcut } from '@/lib/shortcuts-config';
+
+export interface KeyboardShortcutsOptions {
+    onOpenChat?: () => void;
+    onShowShortcutsHelp?: () => void;
+    onCloseModal?: () => void;
+    onOpenCommandPalette?: () => void;
+    onToggleRecording?: () => void;
+    onSaveSoapNote?: () => void;
+    onEditSoapNote?: () => void;
+    onApproveSoapNote?: () => void;
+    onToggleCopilot?: () => void;
+    onActivateBookingAgent?: () => void;
+    onActivateInsightsAgent?: () => void;
+    onShowChatHelp?: () => void;
+    onEditLastMessage?: () => void;
+    enabled?: boolean;
+}
+
+interface KeyboardShortcutsState {
+    shortcutsHelpOpen: boolean;
+    setShortcutsHelpOpen: (open: boolean) => void;
+    lastSequenceKey: string | null;
+}
+
+/**
+ * Check if the current focus is in an input element
+ */
+function isInputFocused(): boolean {
+    const activeElement = document.activeElement;
+    if (!activeElement) return false;
+    
+    const tagName = activeElement.tagName.toLowerCase();
+    const isInput = tagName === 'input' || tagName === 'textarea';
+    const isContentEditable = activeElement.getAttribute('contenteditable') === 'true';
+    
+    return isInput || isContentEditable;
+}
+
+/**
+ * Check if a keyboard event matches a shortcut
+ */
+function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
+    const key = e.key.toLowerCase();
+    const modKey = isMac() ? e.metaKey : e.ctrlKey;
+    
+    // For sequence shortcuts, we handle them differently
+    if (shortcut.isSequence) {
+        return false;
+    }
+    
+    const keys = shortcut.keys;
+    
+    // Check modifier keys
+    const needsMod = keys.includes('mod');
+    const needsShift = keys.includes('shift');
+    const needsAlt = keys.includes('alt');
+    
+    if (needsMod && !modKey) return false;
+    if (!needsMod && modKey) return false;
+    if (needsShift && !e.shiftKey) return false;
+    if (!needsShift && e.shiftKey && key !== 'shift') return false;
+    if (needsAlt && !e.altKey) return false;
+    if (!needsAlt && e.altKey) return false;
+    
+    // Get the actual key (not modifier)
+    const actualKeys = keys.filter(k => !['mod', 'shift', 'alt'].includes(k));
+    
+    if (actualKeys.length === 0) return false;
+    
+    const targetKey = actualKeys[0].toLowerCase();
+    
+    // Handle special keys
+    if (targetKey === 'escape' && key === 'escape') return true;
+    if (targetKey === 'enter' && key === 'enter') return true;
+    if (targetKey === 'space' && (key === ' ' || key === 'space')) return true;
+    if (targetKey === 'arrowup' && key === 'arrowup') return true;
+    if (targetKey === 'arrowdown' && key === 'arrowdown') return true;
+    if (targetKey === 'arrowleft' && key === 'arrowleft') return true;
+    if (targetKey === 'arrowright' && key === 'arrowright') return true;
+    
+    // Handle regular keys
+    if (targetKey === key) return true;
+    if (targetKey === '/' && key === '/') return true;
+    
+    return false;
+}
+
+export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}): KeyboardShortcutsState {
+    const {
+        onOpenChat,
+        onShowShortcutsHelp,
+        onCloseModal,
+        onOpenCommandPalette,
+        onToggleRecording,
+        onSaveSoapNote,
+        onEditSoapNote,
+        onApproveSoapNote,
+        onToggleCopilot,
+        onActivateBookingAgent,
+        onActivateInsightsAgent,
+        onShowChatHelp,
+        onEditLastMessage,
+        enabled = true,
+    } = options;
+
+    const router = useRouter();
+    const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false);
+    const sequenceKeyRef = useRef<string | null>(null);
+    const sequenceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    const handleShowShortcutsHelp = useCallback(() => {
+        if (onShowShortcutsHelp) {
+            onShowShortcutsHelp();
+        } else {
+            setShortcutsHelpOpen(true);
+        }
+    }, [onShowShortcutsHelp]);
+
+    const handleCloseModal = useCallback(() => {
+        if (shortcutsHelpOpen) {
+            setShortcutsHelpOpen(false);
+            return true;
+        }
+        if (onCloseModal) {
+            onCloseModal();
+            return true;
+        }
+        return false;
+    }, [shortcutsHelpOpen, onCloseModal]);
+
+    const executeAction = useCallback((action: string) => {
+        switch (action) {
+            case 'openChat':
+                onOpenChat?.();
+                break;
+            case 'showShortcutsHelp':
+                handleShowShortcutsHelp();
+                break;
+            case 'closeModal':
+                handleCloseModal();
+                break;
+            case 'openCommandPalette':
+                onOpenCommandPalette?.();
+                break;
+            case 'toggleRecording':
+                onToggleRecording?.();
+                break;
+            case 'saveSoapNote':
+                onSaveSoapNote?.();
+                break;
+            case 'editSoapNote':
+                onEditSoapNote?.();
+                break;
+            case 'approveSoapNote':
+                onApproveSoapNote?.();
+                break;
+            case 'toggleCopilot':
+                onToggleCopilot?.();
+                break;
+            case 'activateBookingAgent':
+                onActivateBookingAgent?.();
+                break;
+            case 'activateInsightsAgent':
+                onActivateInsightsAgent?.();
+                break;
+            case 'showChatHelp':
+                onShowChatHelp?.();
+                break;
+            case 'editLastMessage':
+                onEditLastMessage?.();
+                break;
+            case 'goToDashboard':
+                router.push('/home');
+                break;
+            case 'goToSessions':
+                router.push('/appointments');
+                break;
+            case 'goToPatients':
+                router.push('/therapists');
+                break;
+            case 'goToActivity':
+                router.push('/notifications');
+                break;
+            default:
+                break;
+        }
+    }, [
+        onOpenChat,
+        handleShowShortcutsHelp,
+        handleCloseModal,
+        onOpenCommandPalette,
+        onToggleRecording,
+        onSaveSoapNote,
+        onEditSoapNote,
+        onApproveSoapNote,
+        onToggleCopilot,
+        onActivateBookingAgent,
+        onActivateInsightsAgent,
+        onShowChatHelp,
+        onEditLastMessage,
+        router,
+    ]);
+
+    const handleKeyDown = useCallback((e: KeyboardEvent) => {
+        if (!enabled) return;
+
+        const key = e.key.toLowerCase();
+        
+        // Handle Escape key - always works
+        if (key === 'escape') {
+            const handled = handleCloseModal();
+            if (handled) {
+                e.preventDefault();
+            }
+            return;
+        }
+
+        // Handle sequence shortcuts (g + d, g + s, etc.)
+        const sequenceShortcuts = shortcuts.filter(s => s.isSequence);
+        
+        if (sequenceKeyRef.current === 'g') {
+            // We're in a sequence, check for the second key
+            for (const shortcut of sequenceShortcuts) {
+                if (shortcut.keys[0] === 'g' && shortcut.keys[1] === key) {
+                    e.preventDefault();
+                    executeAction(shortcut.action);
+                    sequenceKeyRef.current = null;
+                    if (sequenceTimeoutRef.current) {
+                        clearTimeout(sequenceTimeoutRef.current);
+                        sequenceTimeoutRef.current = null;
+                    }
+                    return;
+                }
+            }
+            // Invalid second key, reset sequence
+            sequenceKeyRef.current = null;
+            if (sequenceTimeoutRef.current) {
+                clearTimeout(sequenceTimeoutRef.current);
+                sequenceTimeoutRef.current = null;
+            }
+        }
+
+        // Start a new sequence if 'g' is pressed (not in input)
+        if (key === 'g' && !isInputFocused() && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+            sequenceKeyRef.current = 'g';
+            // Reset sequence after 1 second
+            if (sequenceTimeoutRef.current) {
+                clearTimeout(sequenceTimeoutRef.current);
+            }
+            sequenceTimeoutRef.current = setTimeout(() => {
+                sequenceKeyRef.current = null;
+            }, 1000);
+            return;
+        }
+
+        // Skip shortcuts when typing in input fields (except for specific shortcuts)
+        const inputFocused = isInputFocused();
+        
+        // Handle non-sequence shortcuts
+        for (const shortcut of shortcuts) {
+            if (shortcut.isSequence) continue;
+            
+            // Skip certain shortcuts when in input
+            if (inputFocused) {
+                // Only allow Escape and modifier-based shortcuts in inputs
+                const hasModifier = shortcut.keys.includes('mod') || shortcut.keys.includes('alt');
+                if (!hasModifier && shortcut.keys[0] !== 'escape') {
+                    continue;
+                }
+            }
+
+            // Special handling for Space in session context
+            if (shortcut.id === 'toggle-recording' && inputFocused) {
+                continue;
+            }
+
+            if (matchesShortcut(e, shortcut)) {
+                e.preventDefault();
+                executeAction(shortcut.action);
+                return;
+            }
+        }
+    }, [enabled, executeAction, handleCloseModal]);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        window.addEventListener('keydown', handleKeyDown);
+        
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            if (sequenceTimeoutRef.current) {
+                clearTimeout(sequenceTimeoutRef.current);
+            }
+        };
+    }, [enabled, handleKeyDown]);
+
+    return {
+        shortcutsHelpOpen,
+        setShortcutsHelpOpen,
+        lastSequenceKey: sequenceKeyRef.current,
+    };
+}

--- a/web/lib/shortcuts-config.ts
+++ b/web/lib/shortcuts-config.ts
@@ -1,0 +1,249 @@
+/**
+ * Keyboard Shortcuts Configuration
+ * Defines all keyboard shortcuts for power users
+ */
+
+export type ShortcutCategory = 'global' | 'chat' | 'navigation' | 'session';
+
+export interface Shortcut {
+    id: string;
+    keys: string[];
+    description: string;
+    category: ShortcutCategory;
+    action: string;
+    isSequence?: boolean;
+}
+
+export interface ShortcutGroup {
+    category: ShortcutCategory;
+    label: string;
+    shortcuts: Shortcut[];
+}
+
+/**
+ * Detects if the user is on macOS
+ */
+export function isMac(): boolean {
+    if (typeof window === 'undefined') return false;
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+}
+
+/**
+ * Returns the modifier key label based on OS
+ */
+export function getModifierKey(): string {
+    return isMac() ? 'Cmd' : 'Ctrl';
+}
+
+/**
+ * Format shortcut keys for display
+ */
+export function formatShortcutKeys(keys: string[], isSequence?: boolean): string {
+    const modKey = getModifierKey();
+    const formattedKeys = keys.map(key => {
+        if (key === 'mod') return modKey;
+        if (key === 'shift') return 'Shift';
+        if (key === 'alt') return 'Alt';
+        if (key === 'enter') return 'Enter';
+        if (key === 'escape') return 'Esc';
+        if (key === 'space') return 'Space';
+        if (key === 'arrowup') return '\u2191';
+        if (key === 'arrowdown') return '\u2193';
+        if (key === 'arrowleft') return '\u2190';
+        if (key === 'arrowright') return '\u2192';
+        return key.toUpperCase();
+    });
+    
+    return isSequence ? formattedKeys.join(' then ') : formattedKeys.join('+');
+}
+
+/**
+ * All keyboard shortcuts configuration
+ */
+export const shortcuts: Shortcut[] = [
+    // Global Shortcuts
+    {
+        id: 'open-chat',
+        keys: ['mod', 'k'],
+        description: 'Open AI chat',
+        category: 'global',
+        action: 'openChat',
+    },
+    {
+        id: 'show-shortcuts',
+        keys: ['mod', '/'],
+        description: 'Show keyboard shortcuts help',
+        category: 'global',
+        action: 'showShortcutsHelp',
+    },
+    {
+        id: 'close-modal',
+        keys: ['escape'],
+        description: 'Close modals/overlays',
+        category: 'global',
+        action: 'closeModal',
+    },
+    {
+        id: 'command-palette',
+        keys: ['mod', 'shift', 'p'],
+        description: 'Open command palette',
+        category: 'global',
+        action: 'openCommandPalette',
+    },
+
+    // Chat Shortcuts
+    {
+        id: 'activate-booking-agent',
+        keys: ['@', 'book'],
+        description: 'Activate BookingAgent',
+        category: 'chat',
+        action: 'activateBookingAgent',
+    },
+    {
+        id: 'activate-insights-agent',
+        keys: ['@', 'insights'],
+        description: 'Activate InsightsAgent',
+        category: 'chat',
+        action: 'activateInsightsAgent',
+    },
+    {
+        id: 'show-chat-help',
+        keys: ['@', 'help'],
+        description: 'Show help',
+        category: 'chat',
+        action: 'showChatHelp',
+    },
+    {
+        id: 'send-message',
+        keys: ['enter'],
+        description: 'Send message',
+        category: 'chat',
+        action: 'sendMessage',
+    },
+    {
+        id: 'new-line',
+        keys: ['shift', 'enter'],
+        description: 'New line',
+        category: 'chat',
+        action: 'newLine',
+    },
+    {
+        id: 'edit-last-message',
+        keys: ['mod', 'arrowup'],
+        description: 'Edit last message',
+        category: 'chat',
+        action: 'editLastMessage',
+    },
+
+    // Navigation Shortcuts (sequences)
+    {
+        id: 'go-to-dashboard',
+        keys: ['g', 'd'],
+        description: 'Go to dashboard',
+        category: 'navigation',
+        action: 'goToDashboard',
+        isSequence: true,
+    },
+    {
+        id: 'go-to-sessions',
+        keys: ['g', 's'],
+        description: 'Go to sessions',
+        category: 'navigation',
+        action: 'goToSessions',
+        isSequence: true,
+    },
+    {
+        id: 'go-to-patients',
+        keys: ['g', 'p'],
+        description: 'Go to patients',
+        category: 'navigation',
+        action: 'goToPatients',
+        isSequence: true,
+    },
+    {
+        id: 'go-to-activity',
+        keys: ['g', 'a'],
+        description: 'Go to activity timeline',
+        category: 'navigation',
+        action: 'goToActivity',
+        isSequence: true,
+    },
+    {
+        id: 'show-nav-shortcuts',
+        keys: ['g', '?'],
+        description: 'Show shortcuts help',
+        category: 'navigation',
+        action: 'showShortcutsHelp',
+        isSequence: true,
+    },
+
+    // Session Shortcuts
+    {
+        id: 'toggle-recording',
+        keys: ['space'],
+        description: 'Start/stop recording',
+        category: 'session',
+        action: 'toggleRecording',
+    },
+    {
+        id: 'save-soap-note',
+        keys: ['mod', 's'],
+        description: 'Save SOAP note',
+        category: 'session',
+        action: 'saveSoapNote',
+    },
+    {
+        id: 'edit-soap-note',
+        keys: ['mod', 'e'],
+        description: 'Edit SOAP note',
+        category: 'session',
+        action: 'editSoapNote',
+    },
+    {
+        id: 'approve-soap-note',
+        keys: ['mod', 'a'],
+        description: 'Approve SOAP note',
+        category: 'session',
+        action: 'approveSoapNote',
+    },
+    {
+        id: 'toggle-copilot',
+        keys: ['mod', 't'],
+        description: 'Toggle copilot sidebar',
+        category: 'session',
+        action: 'toggleCopilot',
+    },
+];
+
+/**
+ * Get shortcuts grouped by category
+ */
+export function getShortcutGroups(): ShortcutGroup[] {
+    const categoryLabels: Record<ShortcutCategory, string> = {
+        global: 'Global',
+        chat: 'Chat',
+        navigation: 'Navigation',
+        session: 'Session',
+    };
+
+    const categories: ShortcutCategory[] = ['global', 'chat', 'navigation', 'session'];
+    
+    return categories.map(category => ({
+        category,
+        label: categoryLabels[category],
+        shortcuts: shortcuts.filter(s => s.category === category),
+    }));
+}
+
+/**
+ * Search shortcuts by description or keys
+ */
+export function searchShortcuts(query: string): Shortcut[] {
+    const lowerQuery = query.toLowerCase();
+    return shortcuts.filter(shortcut => {
+        const descMatch = shortcut.description.toLowerCase().includes(lowerQuery);
+        const keysMatch = shortcut.keys.some(key => key.toLowerCase().includes(lowerQuery));
+        const actionMatch = shortcut.action.toLowerCase().includes(lowerQuery);
+        return descMatch || keysMatch || actionMatch;
+    });
+}


### PR DESCRIPTION
## Summary

Implements comprehensive keyboard shortcuts for power users to enable fast navigation and agent interactions without mouse. This adds:

- **Shortcuts configuration** (`web/lib/shortcuts-config.ts`) - Centralized definition of all shortcuts with OS-aware modifier key handling (Cmd on Mac, Ctrl on Windows)
- **useKeyboardShortcuts hook** (`web/hooks/use-keyboard-shortcuts.ts`) - Global keyboard event handler with support for modifier keys, sequence shortcuts (G+D), and input field detection
- **ShortcutsHelpModal** (`web/components/shortcuts-help-modal.tsx`) - Modal displaying all shortcuts with search and print functionality
- **KeyboardShortcutsProvider** - Context provider integrated into the root layout

Shortcuts implemented:
- **Global:** Cmd+K (chat), Cmd+/ (help), Esc (close), Cmd+Shift+P (palette)
- **Navigation:** G then D (dashboard), G then S (sessions), G then P (patients), G then A (activity)
- **Session:** Space (recording), Cmd+S (save), Cmd+E (edit), Cmd+A (approve), Cmd+T (toggle copilot)
- **Chat:** @book, @insights, @help, Enter (send), Shift+Enter (newline)

## Review & Testing Checklist for Human

- [ ] **Test on both Mac and Windows** - Verify Cmd vs Ctrl modifier key detection works correctly
- [ ] **Verify browser shortcut conflicts** - Cmd+S, Cmd+A, Cmd+E override browser defaults (save page, select all, etc.) - confirm this is acceptable behavior
- [ ] **Test input field detection** - Ensure shortcuts don't fire when typing in text inputs/textareas (except modifier-based ones)
- [ ] **Test sequence shortcuts** - Press G, then within 1 second press D/S/P/A to navigate; verify timeout resets properly
- [ ] **Verify navigation routes** - `goToPatients` routes to `/therapists` - confirm this mapping is intentional

**Recommended test plan:**
1. Open the app and press Cmd+/ (or Ctrl+/) to open shortcuts help modal
2. Search for shortcuts in the modal, verify print functionality
3. Press Esc to close the modal
4. Test navigation: press G then D to go to dashboard, G then S for sessions
5. Click into a text input and verify typing 'g' doesn't trigger navigation
6. Verify Cmd+K, Cmd+S work even when focused in an input

### Notes

Many action handlers (like `onOpenChat`, `onToggleRecording`, `onSaveSoapNote`) are defined but not yet wired up to actual functionality - they will need to be connected in the components that use them. The infrastructure is in place for future integration.

Link to Devin run: https://app.devin.ai/sessions/8bb2fadd3d3d43beb0308d28c1a78af7
Requested by: Swami 086 (@swami086)